### PR TITLE
Fixing a potential Integer Overflow in sendCommand() and improving styling and inline protocol explanation

### DIFF
--- a/src/SparkFun_ATECCX08a_Arduino_Library.cpp
+++ b/src/SparkFun_ATECCX08a_Arduino_Library.cpp
@@ -22,8 +22,6 @@
 */
 
 #include "SparkFun_ATECCX08a_Arduino_Library.h"
-#include <am_util_debug.h>
-#define uprintf am_util_debug_printf
 
 /** \brief
 

--- a/src/SparkFun_ATECCX08a_Arduino_Library.cpp
+++ b/src/SparkFun_ATECCX08a_Arduino_Library.cpp
@@ -110,7 +110,7 @@ error:
 void ATECCX08A::idleMode()
 {
   _i2cPort->beginTransmission(_i2caddr); // set up to write to address
-  _i2cPort->write_byte(WORD_ADDRESS_VALUE_IDLE); // enter idle command (aka word address - the first part of every communication to the IC)
+  _i2cPort->write(WORD_ADDRESS_VALUE_IDLE); // enter idle command (aka word address - the first part of every communication to the IC)
   _i2cPort->endTransmission(); // actually send it
 }
 
@@ -488,9 +488,9 @@ boolean ATECCX08A::receiveResponseData(uint8_t length, boolean debug)
 
     requestAttempts++;
 
-    while (_i2cPort->available2())   // slave may send less than requested
+    while (_i2cPort->available())   // slave may send less than requested
     {
-      uint8_t value = _i2cPort->read2();
+      uint8_t value = _i2cPort->read();
 
       /* Make sure not to read beyond buffer size */
       if (countGlobal < sizeof(inputBuffer))
@@ -503,7 +503,7 @@ boolean ATECCX08A::receiveResponseData(uint8_t length, boolean debug)
     if (requestAttempts == ATRCC508A_MAX_RETRIES)
       break; // this probably means that the device is not responding.
   }
-#if 0
+
   if (debug)
   {
     _debugSerial->print("inputBuffer: ");
@@ -514,7 +514,6 @@ boolean ATECCX08A::receiveResponseData(uint8_t length, boolean debug)
     }
     _debugSerial->println();
   }
-#endif
 
   return true;
 }
@@ -791,16 +790,6 @@ boolean ATECCX08A::read_output(uint8_t zone, uint16_t address, uint8_t length, u
   /* Copy data to output */
   if (output)
   {
-#if 0
-      uprintf("inputBuffer: ");
-      for (i = 0; i < RESPONSE_COUNT_SIZE + length + CRC_SIZE; ++i)
-      {
-          if (inputBuffer[i] >> 4 == 0)
-              uprintf("0");
-          uprintf("%x ", inputBuffer[i]);
-      }
-      uprintf("\r\n");
-#endif
 	  memcpy(output, inputBuffer + RESPONSE_READ_INDEX, length);
   }
 
@@ -856,8 +845,6 @@ boolean ATECCX08A::write(uint8_t zone, uint16_t address, uint8_t *data, uint8_t 
   // If we hear a "0x00", that means it had a successful write
   if (inputBuffer[RESPONSE_SIGNAL_INDEX] != ATRCC508A_SUCCESSFUL_WRITE)
   {
-     uprintf("Write error code: %x\r\n", inputBuffer[RESPONSE_SIGNAL_INDEX]);
-
     goto error;
   }
 
@@ -1185,7 +1172,7 @@ boolean ATECCX08A::sendCommand(uint8_t command_opcode, uint8_t param1, uint16_t 
   wakeUp();
 
   _i2cPort->beginTransmission(_i2caddr);
-  _i2cPort->write2(total_transmission, total_transmission_length);
+  _i2cPort->write(total_transmission, total_transmission_length);
   _i2cPort->endTransmission();
 
   err = true;

--- a/src/SparkFun_ATECCX08a_Arduino_Library.cpp
+++ b/src/SparkFun_ATECCX08a_Arduino_Library.cpp
@@ -135,7 +135,7 @@ boolean ATECCX08A::getInfo()
 
     // Now let's read back from the IC and see if it reports back good things.
   countGlobal = 0;
-  if (receiveResponseData(RESPONSE_COUNT_SIZE + RESPONSE_INFO_SIZE + CRC_SIZE, true) == false)
+  if (!receiveResponseData(RESPONSE_COUNT_SIZE + RESPONSE_INFO_SIZE + CRC_SIZE, true))
     goto error;
 
   idleMode();
@@ -319,7 +319,7 @@ boolean ATECCX08A::updateRandom32Bytes(boolean debug)
 
   // Now let's read back from the IC. This will be 35 bytes of data (count + 32_data_bytes + crc[0] + crc[1])
 
-  if (receiveResponseData(RESPONSE_COUNT_SIZE + RESPONSE_RANDOM_SIZE + CRC_SIZE, debug) == false)
+  if (!receiveResponseData(RESPONSE_COUNT_SIZE + RESPONSE_RANDOM_SIZE + CRC_SIZE, debug))
     goto error;
 
   idleMode();
@@ -650,7 +650,7 @@ boolean ATECCX08A::createNewKeyPair(uint16_t slot)
 
   // Now let's read back from the IC.
 
-  if (receiveResponseData(RESPONSE_COUNT_SIZE + PUBLIC_KEY_SIZE + CRC_SIZE) == false) // public key (64), plus crc (2), plus count (1)
+  if (!receiveResponseData(RESPONSE_COUNT_SIZE + PUBLIC_KEY_SIZE + CRC_SIZE)) // public key (64), plus crc (2), plus count (1)
     goto error;
 
   idleMode();
@@ -695,7 +695,7 @@ boolean ATECCX08A::generatePublicKey(uint16_t slot, boolean debug)
 
   // Now let's read back from the IC.
   // public key (64), plus crc (2), plus count (1)
-  if (receiveResponseData(RESPONSE_COUNT_SIZE + PUBLIC_KEY_SIZE + CRC_SIZE) == false)
+  if (!receiveResponseData(RESPONSE_COUNT_SIZE + PUBLIC_KEY_SIZE + CRC_SIZE))
     goto error;
 
   idleMode();
@@ -769,7 +769,7 @@ boolean ATECCX08A::read(uint8_t zone, uint16_t address, uint8_t length, boolean 
   delay(1); // time for IC to process command and exectute
 
   // Now let's read back from the IC. ( + CRC_SIZE + count)
-  if (receiveResponseData(RESPONSE_COUNT_SIZE + length + CRC_SIZE, debug) == false)
+  if (!receiveResponseData(RESPONSE_COUNT_SIZE + length + CRC_SIZE, debug))
     goto error;
 
   idleMode();
@@ -925,7 +925,7 @@ boolean ATECCX08A::signTempKey(uint16_t slot)
   delay(60); // time for IC to process command and exectute
 
   // Now let's read back from the IC.
-  if (receiveResponseData(RESPONSE_COUNT_SIZE + SIGNATURE_SIZE + CRC_SIZE) == false) // signature (64), plus crc (2), plus count (1)
+  if (!receiveResponseData(RESPONSE_COUNT_SIZE + SIGNATURE_SIZE + CRC_SIZE)) // signature (64), plus crc (2), plus count (1)
     goto error;
 
   idleMode();

--- a/src/SparkFun_ATECCX08a_Arduino_Library.cpp
+++ b/src/SparkFun_ATECCX08a_Arduino_Library.cpp
@@ -23,16 +23,16 @@
 
 #include "SparkFun_ATECCX08a_Arduino_Library.h"
 
-/** \brief 
+/** \brief
 
 	begin(uint8_t i2caddr, TwoWire &wirePort, Stream &serialPort)
-	
+
 	returns false if IC does not respond,
 	returns true if wake() function is successful
-	
+
 	Note, in most SparkFun Arduino Libraries, begin would call a different
-	function called isConnected() to check status on the bus, but because 
-	this IC will ACK and respond with a status, we are gonna use wakeUp() 
+	function called isConnected() to check status on the bus, but because
+	this IC will ACK and respond with a status, we are gonna use wakeUp()
 	for the same purpose.
 */
 
@@ -40,7 +40,7 @@ boolean ATECCX08A::begin(uint8_t i2caddr, TwoWire &wirePort, Stream &serialPort)
 {
   //Bring in the user's choices
   _i2cPort = &wirePort; //Grab which port the user wants us to use
-  
+
   _debugSerial = &serialPort; //Grab which port the user wants us to use
 
   _i2caddr = i2caddr;
@@ -48,18 +48,18 @@ boolean ATECCX08A::begin(uint8_t i2caddr, TwoWire &wirePort, Stream &serialPort)
   return ( wakeUp() ); // see if the IC wakes up properly, return responce.
 }
 
-/** \brief 
+/** \brief
 
 	wakeUp()
-	
+
 	This function wakes up the ATECCX08a IC
 	Returns TRUE if the IC responds with correct verification
-	Message (0x04, 0x11, 0x33, 0x44) 
+	Message (0x04, 0x11, 0x33, 0x44)
 	The actual status byte we are looking for is the 0x11.
 	The complete message is as follows:
 	COUNT, DATA, CRC[0], CRC[1].
 	0x11 means that it received the wake condition and is goat to goo.
-	
+
 	Note, in most SparkFun Arduino Libraries, we would use a different
 	function called isConnected(), but because this IC will ACK and
 	respond with a status, we are gonna use wakeUp() for the same purpose.
@@ -76,7 +76,7 @@ boolean ATECCX08A::wakeUp()
   // 1500 uSeconds is minimum and known as "Wake High Delay to Data Comm." tWHI, and SDA must be high during this time.
 
   // Now let's read back from the IC and see if it reports back good things.
-  countGlobal = 0; 
+  countGlobal = 0;
   if(receiveResponseData(4) == false) return false;
   if(checkCount() == false) return false;
   if(checkCrc() == false) return false;
@@ -87,7 +87,7 @@ boolean ATECCX08A::wakeUp()
 /** \brief
 
 	idleMode()
-	
+
 	The ATECCX08A goes into the idle mode and ignores all subsequent I/O transitions
 	until the next wake flag. The contents of TempKey and RNG Seed registers are retained.
 	Idle Power Supply Current: 800uA.
@@ -98,13 +98,13 @@ void ATECCX08A::idleMode()
 {
   _i2cPort->beginTransmission(_i2caddr); // set up to write to address
   _i2cPort->write(WORD_ADDRESS_VALUE_IDLE); // enter idle command (aka word address - the first part of every communication to the IC)
-  _i2cPort->endTransmission(); // actually send it  
+  _i2cPort->endTransmission(); // actually send it
 }
 
 /** \brief
 
 	getInfo()
-	
+
 	This function sends the INFO Command and listens for the correct version (0x50) within the response.
 	The Info command has a mode parameter, and in this function we are using the "Revision" mode (0x00)
 	At the time of data sheet creation the Info command will return 0x00 0x00 0x50 0x00. For
@@ -117,9 +117,9 @@ boolean ATECCX08A::getInfo()
   sendCommand(COMMAND_OPCODE_INFO, 0x00, 0x0000); // param1 - 0x00 (revision mode).
 
   delay(1); // time for IC to process command and exectute
-  
+
     // Now let's read back from the IC and see if it reports back good things.
-  countGlobal = 0; 
+  countGlobal = 0;
   if(receiveResponseData(7, true) == false) return false;
   idleMode();
   if(checkCount() == false) return false;
@@ -131,8 +131,8 @@ boolean ATECCX08A::getInfo()
 /** \brief
 
 	lockConfig()
-	
-	This function sends the LOCK Command with the configuration zone parameter, 
+
+	This function sends the LOCK Command with the configuration zone parameter,
 	and listens for success response (0x00).
 */
 
@@ -144,7 +144,7 @@ boolean ATECCX08A::lockConfig()
 /** \brief
 
 	readConfigZone()
-	
+
 	This function reads the entire configuration zone EEPROM memory on the device.
 	It stores them for vewieing in a large array called configZone[128].
 	In addition to configuration settings, the configuration memory on the IC also
@@ -155,37 +155,37 @@ boolean ATECCX08A::lockConfig()
 boolean ATECCX08A::readConfigZone(boolean debug)
 {
   // read block 0, the first 32 bytes of config zone into inputBuffer
-  read(ZONE_CONFIG, ADDRESS_CONFIG_READ_BLOCK_0, 32); 
-  
+  read(ZONE_CONFIG, ADDRESS_CONFIG_READ_BLOCK_0, 32);
+
   // copy current contents of inputBuffer into configZone[] (for later viewing/comparing)
   memcpy(&configZone[0], &inputBuffer[1], 32);
-  
+
   read(ZONE_CONFIG, ADDRESS_CONFIG_READ_BLOCK_1, 32); 	// read block 1
   memcpy(&configZone[32], &inputBuffer[1], 32); 	// copy block 1
-  
+
   read(ZONE_CONFIG, ADDRESS_CONFIG_READ_BLOCK_2, 32); 	// read block 2
   memcpy(&configZone[64], &inputBuffer[1], 32); 	// copy block 2
-  
+
   read(ZONE_CONFIG, ADDRESS_CONFIG_READ_BLOCK_3, 32); 	// read block 3
-  memcpy(&configZone[96], &inputBuffer[1], 32); 	// copy block 3  
-  
+  memcpy(&configZone[96], &inputBuffer[1], 32); 	// copy block 3
+
   // pull out serial number from configZone, and copy to public variable within this instance
-  memcpy(&serialNumber[0], &configZone[0], 4); 	// copy SN<0:3> 
-  memcpy(&serialNumber[4], &configZone[8], 5); 	// copy SN<4:8> 
-  
+  memcpy(&serialNumber[0], &configZone[0], 4); 	// copy SN<0:3>
+  memcpy(&serialNumber[4], &configZone[8], 5); 	// copy SN<4:8>
+
   // pull out revision number from configZone, and copy to public variable within this instance
-  memcpy(&revisionNumber[0], &configZone[4], 4); 	// copy RevNum<0:3>   
-  
+  memcpy(&revisionNumber[0], &configZone[4], 4); 	// copy RevNum<0:3>
+
   // set lock statuses for config, data/otp, and slot 0
   if(configZone[87] == 0x00) configLockStatus = true;
   else configLockStatus = false;
-  
+
   if(configZone[86] == 0x00) dataOTPLockStatus = true;
   else dataOTPLockStatus = false;
-  
+
   if( (configZone[88] & (1<<0) ) == true) slot0LockStatus = false; // LSB is slot 0. if bit set = UN-locked.
   else slot0LockStatus = true;
-  
+
   if(debug)
   {
     _debugSerial->println("configZone: ");
@@ -194,23 +194,23 @@ boolean ATECCX08A::readConfigZone(boolean debug)
       _debugSerial->print(i);
 	  _debugSerial->print(": 0x");
 	  if((configZone[i] >> 4) == 0) _debugSerial->print("0"); // print preceeding high nibble if it's zero
-	  _debugSerial->print(configZone[i], HEX); 
+	  _debugSerial->print(configZone[i], HEX);
 	  _debugSerial->print(" \t0b");
 	  for(int bit = 7; bit >= 0; bit--) _debugSerial->print(bitRead(configZone[i],bit)); // print binary WITH preceding '0' bits
 	  _debugSerial->println();
     }
     _debugSerial->println();
   }
-  
-  
+
+
   return true;
 }
 
 /** \brief
 
 	lockDataAndOTP()
-	
-	This function sends the LOCK Command with the Data and OTP (one-time-programming) zone parameter, 
+
+	This function sends the LOCK Command with the Data and OTP (one-time-programming) zone parameter,
 	and listens for success response (0x00).
 */
 
@@ -222,8 +222,8 @@ boolean ATECCX08A::lockDataAndOTP()
 /** \brief
 
 	lockDataSlot0()
-	
-	This function sends the LOCK Command with the Slot 0 zone parameter, 
+
+	This function sends the LOCK Command with the Slot 0 zone parameter,
 	and listens for success response (0x00).
 */
 
@@ -235,8 +235,8 @@ boolean ATECCX08A::lockDataSlot0()
 /** \brief
 
 	lock(byte zone)
-	
-	This function sends the LOCK Command using the argument zone as parameter 1, 
+
+	This function sends the LOCK Command using the argument zone as parameter 1,
 	and listens for success response (0x00).
 */
 
@@ -245,9 +245,9 @@ boolean ATECCX08A::lock(uint8_t zone)
   sendCommand(COMMAND_OPCODE_LOCK, zone, 0x0000);
 
   delay(32); // time for IC to process command and exectute
-  
+
   // Now let's read back from the IC and see if it reports back good things.
-  countGlobal = 0; 
+  countGlobal = 0;
   if(receiveResponseData(4) == false) return false;
   idleMode();
   if(checkCount() == false) return false;
@@ -259,7 +259,7 @@ boolean ATECCX08A::lock(uint8_t zone)
 /** \brief
 
 	updateRandom32Bytes(boolean debug)
-	
+
     This function pulls a complete random number (all 32 bytes)
     It stores it in a global array called random32Bytes[]
     If you wish to access this global variable and use as a 256 bit random number,
@@ -271,7 +271,7 @@ boolean ATECCX08A::lock(uint8_t zone)
 
 boolean ATECCX08A::updateRandom32Bytes(boolean debug)
 {
-  sendCommand(COMMAND_OPCODE_RANDOM, 0x00, 0x0000); 
+  sendCommand(COMMAND_OPCODE_RANDOM, 0x00, 0x0000);
   // param1 = 0. - Automatically update EEPROM seed only if necessary prior to random number generation. Recommended for highest security.
   // param2 = 0x0000. - must be 0x0000.
 
@@ -283,8 +283,8 @@ boolean ATECCX08A::updateRandom32Bytes(boolean debug)
   idleMode();
   if(checkCount(debug) == false) return false;
   if(checkCrc(debug) == false) return false;
-  
-  
+
+
   // update random32Bytes[] array
   // we don't need the count value (which is currently the first byte of the inputBuffer)
   for (int i = 0 ; i < 32 ; i++) // for loop through to grab all but the first position (which is "count" of the message)
@@ -302,14 +302,14 @@ boolean ATECCX08A::updateRandom32Bytes(boolean debug)
     }
     _debugSerial->println();
   }
-  
+
   return true;
 }
 
 /** \brief
 
 	getRandomByte(boolean debug)
-	
+
     This function returns a random byte.
 	It calls updateRandom32Bytes(), then uses the first byte in that array for a return value.
 */
@@ -323,7 +323,7 @@ byte ATECCX08A::getRandomByte(boolean debug)
 /** \brief
 
 	getRandomInt(boolean debug)
-	
+
     This function returns a random Int.
 	It calls updateRandom32Bytes(), then uses the first 2 bytes in that array for a return value.
 	It bitwize ORS the first two bytes of the array into the return value.
@@ -342,7 +342,7 @@ int ATECCX08A::getRandomInt(boolean debug)
 /** \brief
 
 	getRandomLong(boolean debug)
-	
+
     This function returns a random Long.
 	It calls updateRandom32Bytes(), then uses the first 4 bytes in that array for a return value.
 	It bitwize ORS the first 4 bytes of the array into the return value.
@@ -365,7 +365,7 @@ long ATECCX08A::getRandomLong(boolean debug)
 /** \brief
 
 	random(long max)
-	
+
     This function returns a positive random Long between 0 and max
 	max can be up to the larges positive value of a long: 2147483647
 */
@@ -378,7 +378,7 @@ long ATECCX08A::random(long max)
 /** \brief
 
 	random(long min, long max)
-	
+
     This function returns a random Long with set boundaries of min and max.
 	If you flip min and max, it still works!
 	Also, it can handle negative numbers. Wahoo!
@@ -396,13 +396,13 @@ long ATECCX08A::random(long min, long max)
 /** \brief
 
 	receiveResponseData(uint8_t length, boolean debug)
-	
+
 	This function receives messages from the ATECCX08a IC (up to 128 Bytes)
 	It will return true if it receives the correct amount of data and good CRCs.
 	What we hear back from the IC is always formatted with the following series of bytes:
 	COUNT, DATA, CRC[0], CRC[1]
-	Note, the count number includes itself, the num of data bytes, and the two CRC bytes in the total, 
-	so a simple response message from the IC that indicates that it heard the wake 
+	Note, the count number includes itself, the num of data bytes, and the two CRC bytes in the total,
+	so a simple response message from the IC that indicates that it heard the wake
 	condition properly is like so:
 	EXAMPLE Wake success response: 0x04, 0x11, 0x33, 0x44
 	It needs length argument:
@@ -410,51 +410,69 @@ long ATECCX08A::random(long min, long max)
 */
 
 boolean ATECCX08A::receiveResponseData(uint8_t length, boolean debug)
-{	
+{
 
   // pull in data 32 bytes at at time. (necessary to avoid overflow on atmega328)
   // if length is less than or equal to 32, then just pull it in.
   // if length is greater than 32, then we must first pull in 32, then pull in remainder.
   // lets use length as our tracker and we will subtract from it as we pull in data.
-  
+
   countGlobal = 0; // reset for each new message (most important, like wensleydale at a cheese party)
   cleanInputBuffer();
   byte requestAttempts = 0; // keep track of how many times we've attempted to request, to break out if necessary
-  
+
+  /* Normalize length according to buffer size */
+  if (length > sizeof(inputBuffer))
+    length = sizeof(inputBuffer);
+
   while(length)
   {
     byte requestAmount; // amount of bytes to request, needed to pull in data 32 bytes at a time
-	if(length > 32) requestAmount = 32; // as we have more than 32 to pull in, keep pulling in 32 byte chunks
-	else requestAmount = length; // now we're ready to pull in the last chunk.
-	_i2cPort->requestFrom(_i2caddr, requestAmount);    // request bytes from slave
-	requestAttempts++;
+    if(length > ATRCC508A_MAX_REQUEST_SIZE)
+    {
+      requestAmount = ATRCC508A_MAX_REQUEST_SIZE; // as we have more than 32 to pull in, keep pulling in 32 byte chunks
+    }
+    else
+    {
+      requestAmount = length; // now we're ready to pull in the last chunk.
+    }
 
-	while (_i2cPort->available())   // slave may send less than requested
-	{
-	  inputBuffer[countGlobal] = _i2cPort->read();    // receive a byte as character
-	  length--; // keep this while loop active until we've pulled in everything
-	  countGlobal++; // keep track of the count of the entire message.
-	}  
-	if(requestAttempts == 20) break; // this probably means that the device is not responding.
+    _i2cPort->requestFrom(_i2caddr, requestAmount);    // request bytes from slave
+    requestAttempts++;
+
+    while (_i2cPort->available())   // slave may send less than requested
+    {
+      uint8_t value = _i2cPort->read();
+
+      /* Make sure not to read beyond buffer size */
+      if (countGlobal < sizeof(inputBuffer))
+        inputBuffer[countGlobal] = value;    // receive a byte as character
+      length--; // keep this while loop active until we've pulled in everything
+      countGlobal++; // keep track of the count of the entire message.
+    }
+
+    if(requestAttempts == ATRCC508A_MAX_RETRIES)
+      break; // this probably means that the device is not responding.
   }
 
   if(debug)
   {
     _debugSerial->print("inputBuffer: ");
-	for (int i = 0; i < countGlobal ; i++)
-	{
-	  _debugSerial->print(inputBuffer[i], HEX);
-	  _debugSerial->print(",");
-	}
-	_debugSerial->println();	  
+    for (int i = 0; i < countGlobal ; i++)
+    {
+      _debugSerial->print(inputBuffer[i], HEX);
+      _debugSerial->print(",");
+    }
+    _debugSerial->println();
   }
+
   return true;
 }
 
 /** \brief
 
 	checkCount(boolean debug)
-	
+
 	This function checks that the count byte received in the most recent message equals countGlobal
 	Call receiveResponseData, and then imeeditately call this to check the count of the complete message.
 	Returns true if inputBuffer[0] == countGlobal.
@@ -470,18 +488,18 @@ boolean ATECCX08A::checkCount(boolean debug)
     _debugSerial->println(inputBuffer[0], HEX);
   }
   // Check count; the first byte sent from IC is count, and it should be equal to the actual message count
-  if(inputBuffer[0] != countGlobal) 
+  if(inputBuffer[0] != countGlobal)
   {
 	if(debug) _debugSerial->println("Message Count Error");
 	return false;
-  }  
+  }
   return true;
 }
 
 /** \brief
 
 	checkCrc(boolean debug)
-	
+
 	This function checks that the CRC bytes received in the most recent message equals a calculated CRCs
 	Call receiveResponseData, then call immediately call this to check the CRCs of the complete message.
 */
@@ -489,9 +507,8 @@ boolean ATECCX08A::checkCount(boolean debug)
 boolean ATECCX08A::checkCrc(boolean debug)
 {
   // Check CRC[0] and CRC[1] are good to go.
-  
-  atca_calculate_crc(countGlobal-2, inputBuffer);   // first calculate it
-  
+  atca_calculate_crc(countGlobal - CRC_SIZE, inputBuffer);   // first calculate it
+
   if(debug)
   {
     _debugSerial->print("CRC[0] Calc: 0x");
@@ -499,20 +516,20 @@ boolean ATECCX08A::checkCrc(boolean debug)
 	_debugSerial->print("CRC[1] Calc: 0x");
     _debugSerial->println(crc[1], HEX);
   }
-  
+
   if( (inputBuffer[countGlobal-1] != crc[1]) || (inputBuffer[countGlobal-2] != crc[0]) )   // then check the CRCs.
   {
 	if(debug) _debugSerial->println("Message CRC Error");
 	return false;
   }
-  
+
   return true;
 }
 
 /** \brief
 
 	atca_calculate_crc(uint8_t length, uint8_t *data)
-	
+
     This function calculates CRC.
     It was copied directly from the App Note provided from Microchip.
     Note, it seems to be their own unique type of CRC cacluation.
@@ -546,7 +563,7 @@ void ATECCX08A::atca_calculate_crc(uint8_t length, uint8_t *data)
 /** \brief
 
 	cleanInputBuffer()
-	
+
     This function sets the entire inputBuffer to 0xFFs.
 	It is helpful for debugging message/count/CRCs errors.
 */
@@ -562,31 +579,31 @@ void ATECCX08A::cleanInputBuffer()
 /** \brief
 
 	createNewKeyPair(uint16_t slot)
-	
+
     This function sends the command to create a new key pair (private AND public)
 	in the slot designated by argument slot (default slot 0).
 	Sparkfun Default Configuration Sketch calls this, and then locks the data/otp zones and slot 0.
 */
 
 boolean ATECCX08A::createNewKeyPair(uint16_t slot)
-{  
+{
   sendCommand(COMMAND_OPCODE_GENKEY, GENKEY_MODE_NEW_PRIVATE, slot);
 
   delay(115); // time for IC to process command and exectute
 
   // Now let's read back from the IC.
-  
-  if(receiveResponseData(64 + 2 + 1) == false) return false; // public key (64), plus crc (2), plus count (1)
+
+  if(receiveResponseData(PUBLIC_KEY_SIZE + CRC_SIZE + 1) == false) return false; // public key (64), plus crc (2), plus count (1)
   idleMode();
   boolean checkCountResult = checkCount();
   boolean checkCrcResult = checkCrc();
-  
-  
+
+
   // update publicKey64Bytes[] array
   if(checkCountResult && checkCrcResult) // check that it was a good message
   {
 	// we don't need the count value (which is currently the first byte of the inputBuffer)
-	for (int i = 0 ; i < 64 ; i++) // for loop through to grab all but the first position (which is "count" of the message)
+	for (int i = 0 ; i < PUBLIC_KEY_SIZE ; i++) // for loop through to grab all but the first position (which is "count" of the message)
 	{
 	  publicKey64Bytes[i] = inputBuffer[i + 1];
 	}
@@ -600,13 +617,13 @@ boolean ATECCX08A::createNewKeyPair(uint16_t slot)
 	generatePublicKey(uint16_t slot, boolean debug)
 
     This function uses the GENKEY command in "Public Key Computation" mode.
-	
+
     Generates an ECC public key based upon the private key stored in the slot defined by the KeyID
-	parameter (aka slot). Defaults to slot 0. 
-	
+	parameter (aka slot). Defaults to slot 0.
+
 	Note, if you haven't created a private key in the slot already, then this will fail.
-	
-	The generated public key is read back from the device, and then copied from inputBuffer to 
+
+	The generated public key is read back from the device, and then copied from inputBuffer to
 	a global variable named publicKey64Bytes for later use.
 */
 
@@ -617,21 +634,20 @@ boolean ATECCX08A::generatePublicKey(uint16_t slot, boolean debug)
   delay(115); // time for IC to process command and exectute
 
   // Now let's read back from the IC.
-  
-  if(receiveResponseData(64 + 2 + 1) == false) return false; // public key (64), plus crc (2), plus count (1)
+  if(receiveResponseData(PUBLIC_KEY_SIZE + CRC_SIZE + 1) == false) return false; // public key (64), plus crc (2), plus count (1)
   idleMode();
   boolean checkCountResult = checkCount();
   boolean checkCrcResult = checkCrc();
-  
+
   // update publicKey64Bytes[] array
   if(checkCountResult && checkCrcResult) // check that it was a good message
-  {  
+  {
     // we don't need the count value (which is currently the first byte of the inputBuffer)
-    for (int i = 0 ; i < 64 ; i++) // for loop through to grab all but the first position (which is "count" of the message)
+    for (int i = 0 ; i < PUBLIC_KEY_SIZE ; i++) // for loop through to grab all but the first position (which is "count" of the message)
     {
       publicKey64Bytes[i] = inputBuffer[i + 1];
     }
-	
+
 	if(debug)
 	{
 		_debugSerial->println("This device's Public Key:");
@@ -659,17 +675,17 @@ boolean ATECCX08A::generatePublicKey(uint16_t slot, boolean debug)
 
     Reads data from the IC at a specific zone and address.
 	Your data response will be available at inputBuffer[].
-	
+
 	For more info on address encoding, see datasheet pg 58.
 */
 
 boolean ATECCX08A::read(uint8_t zone, uint16_t address, uint8_t length, boolean debug)
 {
   // adjust zone as needed for whether it's 4 or 32 bytes length read
-  // bit 7 of zone needs to be set correctly 
-  // (0 = 4 Bytes are read) 
+  // bit 7 of zone needs to be set correctly
+  // (0 = 4 Bytes are read)
   // (1 = 32 Bytes are read)
-  if(length == 32) 
+  if(length == 32)
   {
 	zone |= 0b10000000; // set bit 7
   }
@@ -683,16 +699,15 @@ boolean ATECCX08A::read(uint8_t zone, uint16_t address, uint8_t length, boolean 
   }
 
   sendCommand(COMMAND_OPCODE_READ, zone, address);
-  
+
   delay(1); // time for IC to process command and exectute
 
-  // Now let's read back from the IC. 
-  
+  // Now let's read back from the IC.
   if(receiveResponseData(length + 3, debug) == false) return false;
   idleMode();
   if(checkCount(debug) == false) return false;
   if(checkCrc(debug) == false) return false;
-  
+
   return true;
 }
 
@@ -701,17 +716,17 @@ boolean ATECCX08A::read(uint8_t zone, uint16_t address, uint8_t length, boolean 
 	write(uint8_t zone, uint16_t address, uint8_t *data, uint8_t length_of_data)
 
     Writes data to a specific zone and address on the IC.
-	
+
 	For more info on zone and address encoding, see datasheet pg 58.
 */
 
 boolean ATECCX08A::write(uint8_t zone, uint16_t address, uint8_t *data, uint8_t length_of_data)
 {
   // adjust zone as needed for whether it's 4 or 32 bytes length write
-  // bit 7 of param1 needs to be set correctly 
-  // (0 = 4 Bytes are written) 
+  // bit 7 of param1 needs to be set correctly
+  // (0 = 4 Bytes are written)
   // (1 = 32 Bytes are written)
-  if(length_of_data == 32) 
+  if(length_of_data == 32)
   {
 	zone |= 0b10000000; // set bit 7
   }
@@ -723,13 +738,13 @@ boolean ATECCX08A::write(uint8_t zone, uint16_t address, uint8_t *data, uint8_t 
   {
 	return 0; // invalid length, abort.
   }
- 
+
   sendCommand(COMMAND_OPCODE_WRITE, zone, address, data, length_of_data);
 
   delay(26); // time for IC to process command and exectute
-  
+
   // Now let's read back from the IC and see if it reports back good things.
-  countGlobal = 0; 
+  countGlobal = 0;
   if(receiveResponseData(4) == false) return false;
   idleMode();
   if(checkCount() == false) return false;
@@ -745,9 +760,9 @@ boolean ATECCX08A::write(uint8_t zone, uint16_t address, uint8_t *data, uint8_t 
     Creates a 64-byte ECC signature on 32 bytes of data.
 	Defautes to use private key located in slot 0.
 	Your signature will be available at global variable signature[].
-	
+
 	Note, the IC actually needs you to store your data in a temporary memory location
-	called TempKey. This function first loads TempKey, and then signs TempKey. Then it 
+	called TempKey. This function first loads TempKey, and then signs TempKey. Then it
 	receives the signature and copies it to signature[].
 */
 
@@ -776,21 +791,20 @@ boolean ATECCX08A::createSignature(uint8_t *data, uint16_t slot)
 boolean ATECCX08A::loadTempKey(uint8_t *data)
 {
   sendCommand(COMMAND_OPCODE_NONCE, NONCE_MODE_PASSTHROUGH, 0x0000, data, 32);
-  
+
   // note, param2 is 0x0000 (and param1 is PASSTHROUGH), so OutData will be just a single byte of zero upon completion.
   // see ds pg 77 for more info
 
   delay(7); // time for IC to process command and exectute
 
   // Now let's read back from the IC.
-  
   if(receiveResponseData(4) == false) return false; // responds with "0x00" if NONCE executed properly
   idleMode();
   boolean checkCountResult = checkCount();
   boolean checkCrcResult = checkCrc();
-  
+
   if( (checkCountResult == false) || (checkCrcResult == false) ) return false;
-  
+
   if(inputBuffer[1] == 0x00) return true;   // If we hear a "0x00", that means it had a successful nonce
   else return false;
 }
@@ -801,7 +815,7 @@ boolean ATECCX08A::loadTempKey(uint8_t *data)
 
 	Create a 64 byte ECC signature for the contents of TempKey using the private key in Slot.
 	Default slot is 0.
-	
+
 	The response from this command (the signature) is stored in global varaible signature[].
 */
 
@@ -812,21 +826,20 @@ boolean ATECCX08A::signTempKey(uint16_t slot)
   delay(60); // time for IC to process command and exectute
 
   // Now let's read back from the IC.
-  
-  if(receiveResponseData(64 + 2 + 1) == false) return false; // signature (64), plus crc (2), plus count (1)
+  if(receiveResponseData(SIGNATURE_SIZE + CRC_SIZE + 1) == false) return false; // signature (64), plus crc (2), plus count (1)
   idleMode();
   boolean checkCountResult = checkCount();
   boolean checkCrcResult = checkCrc();
-  
+
   // update signature[] array and print it to serial terminal nicely formatted for easy copy/pasting between sketches
   if(checkCountResult && checkCrcResult) // check that it was a good message
-  {  
+  {
     // we don't need the count value (which is currently the first byte of the inputBuffer)
-    for (int i = 0 ; i < 64 ; i++) // for loop through to grab all but the first position (which is "count" of the message)
+    for (int i = 0 ; i < SIGNATURE_SIZE ; i++) // for loop through to grab all but the first position (which is "count" of the message)
     {
       signature[i] = inputBuffer[i + 1];
     }
-  
+
 	_debugSerial->println();
     _debugSerial->println("uint8_t signature[64] = {");
     for (int i = 0; i < sizeof(signature) ; i++)
@@ -846,10 +859,10 @@ boolean ATECCX08A::signTempKey(uint16_t slot)
 /** \brief
 
 	verifySignature(uint8_t *message, uint8_t *signature, uint8_t *publicKey)
-	
+
 	Verifies a ECC signature using the message, signature and external public key.
 	Returns true if successful.
-	
+
 	Note, it acutally uses loadTempKey, then uses the verify command in "external public key" mode.
 */
 
@@ -857,30 +870,29 @@ boolean ATECCX08A::verifySignature(uint8_t *message, uint8_t *signature, uint8_t
 {
   // first, let's load the message into TempKey on the device, this uses NONCE command in passthrough mode.
   boolean loadTempKeyResult = loadTempKey(message);
-  if(loadTempKeyResult == false) 
+  if(loadTempKeyResult == false)
   {
     _debugSerial->println("Load TempKey Failure");
     return false;
   }
 
   // We can only send one *single* data array to sendCommand as Param2, so we need to combine signature and public key.
-  uint8_t data_sigAndPub[128]; 
-  memcpy(&data_sigAndPub[0], &signature[0], 64);	// append signature
-  memcpy(&data_sigAndPub[64], &publicKey[0], 64);	// append external public key
-  
+  uint8_t data_sigAndPub[128];
+  memcpy(&data_sigAndPub[0], &signature[0], SIGNATURE_SIZE);	// append signature
+  memcpy(&data_sigAndPub[SIGNATURE_SIZE], &publicKey[0], PUBLIC_KEY_SIZE);	// append external public key
+
   sendCommand(COMMAND_OPCODE_VERIFY, VERIFY_MODE_EXTERNAL, VERIFY_PARAM2_KEYTYPE_ECC, data_sigAndPub, sizeof(data_sigAndPub));
 
   delay(58); // time for IC to process command and exectute
 
   // Now let's read back from the IC.
-  
   if(receiveResponseData(4) == false) return false;
   idleMode();
   boolean checkCountResult = checkCount();
   boolean checkCrcResult = checkCrc();
-  
+
   if( (checkCountResult == false) || (checkCrcResult == false) ) return false;
-  
+
   if(inputBuffer[1] == 0x00) return true;   // If we hear a "0x00", that means it had a successful verify
   else return false;
 }
@@ -888,19 +900,19 @@ boolean ATECCX08A::verifySignature(uint8_t *message, uint8_t *signature, uint8_t
 /** \brief
 
 	writeConfigSparkFun()
-	
+
 	Writes the necessary configuration settings to the IC in order to work with the SparkFun Arduino Library examples.
 	For key slots 0 and 1, this enables ECC private key pairs,public key generation, and external signature verifications.
-	
+
 	Returns true if write commands were successful.
 */
 
 boolean ATECCX08A::writeConfigSparkFun()
 {
   // keep track of our write command results.
-  boolean result1; 
+  boolean result1;
   boolean result2;
-  
+
   // set keytype on slot 0 and 1 to 0x3300
   // Lockable, ECC, PuInfo set (public key always allowed to be generated), contains a private Key
   uint8_t data1[] = {0x33, 0x00, 0x33, 0x00}; // 0x3300 sets the keyconfig.keyType, see datasheet pg 20
@@ -909,21 +921,21 @@ boolean ATECCX08A::writeConfigSparkFun()
   // EXT signatures, INT signatures, IsSecret, Write config never
   uint8_t data2[] = {0x83, 0x20, 0x83, 0x20}; // for slot config bit definitions see datasheet pg 20
   result2 = write(ZONE_CONFIG, (20 / 4), data2, 4);
-  
+
   return (result1 && result2);
 }
 
 /** \brief
 
 	sendCommand(uint8_t command_opcode, uint8_t param1, uint16_t param2, uint8_t *data, size_t length_of_data)
-	
-	Generic function for sending commands to the IC. 
-	
+
+	Generic function for sending commands to the IC.
+
 	This function handles creating the "total transmission" to the IC.
 	This contains WORD_ADDRESS_VALUE, COUNT, OPCODE, PARAM1, PARAM2, DATA (optional), and CRCs.
-	
+
 	Note, it always calls the "wake()" function, assuming that you have let the IC fall asleep (default 1.7 sec)
-	
+
 	Note, for anything other than a command (reset, sleep and idle), you need a different "Word Address Value",
 	So those specific transmissions are handled in unique functions.
 */
@@ -932,23 +944,30 @@ boolean ATECCX08A::sendCommand(uint8_t command_opcode, uint8_t param1, uint16_t 
 {
   // build packet array (total_transmission) to send a communication to IC, with opcode COMMAND
   // It expects to see: word address, count, command opcode, param1, param2, data (optional), CRC[0], CRC[1]
-  
+  uint8_t transmission_without_crc_length;
   uint8_t total_transmission_length;
-  total_transmission_length = (1 +1 +1 +1 +2 +length_of_data +2); 
-  // word address val (1) + count (1) + command opcode (1) param1 (1) + param2 (2) data (0-?) + crc (2)
+  uint8_t total_transmission[UINT8_MAX];
+  uint8_t packet_to_CRC[UINT8_MAX]; // minus word address (1) and crc (2).
+  boolean err = false;
 
-  uint8_t total_transmission[total_transmission_length];
-  total_transmission[0] = WORD_ADDRESS_VALUE_COMMAND; 		// word address value (type command)
-  total_transmission[1] = total_transmission_length-1; 		// count, does not include itself, so "-1"
-  total_transmission[2] = command_opcode; 			// command
-  total_transmission[3] = param1;							// param1
-  memcpy(&total_transmission[4], &param2, sizeof(param2));	// append param2 
-  memcpy(&total_transmission[6], &data[0], length_of_data);	// append data
-  
+  /* Validate no integer overflow */
+  if (length_of_data >= UINT8_MAX - ATRCC508A_PROTOCOL_OVERHEAD)
+    goto error;
+
+  total_transmission_length = length_of_data + ATRCC508A_PROTOCOL_OVERHEAD;
+
+  total_transmission[ATRCC508A_PROTOCOL_FIELD_COMMAND] = WORD_ADDRESS_VALUE_COMMAND;      // word address value (type command)
+  total_transmission[ATRCC508A_PROTOCOL_FIELD_LENGTH] = total_transmission_length - ATRCC508A_PROTOCOL_FIELD_SIZE_LENGTH;    // count, does not include itself, so "-1"
+  total_transmission[ATRCC508A_PROTOCOL_FIELD_OPCODE] = command_opcode;                   // command
+  total_transmission[ATRCC508A_PROTOCOL_FIELD_PARAM1] = param1;                           // param1
+  memcpy(&total_transmission[ATRCC508A_PROTOCOL_FIELD_PARAM2], &param2, sizeof(param2));  // append param2
+  memcpy(&total_transmission[ATRCC508A_PROTOCOL_FIELD_DATA], &data[0], length_of_data);   // append data
+
   // update CRCs
-  uint8_t packet_to_CRC[total_transmission_length-3]; // minus word address (1) and crc (2).
-  memcpy(&packet_to_CRC[0], &total_transmission[1], (total_transmission_length-3)); // copy over just what we need to CRC starting at index 1
-  
+  transmission_without_crc_length = total_transmission_length - (ATRCC508A_PROTOCOL_FIELD_SIZE_COMMAND + ATRCC508A_PROTOCOL_FIELD_SIZE_CRC); // copy over just what we need to CRC starting at index 1
+
+  memcpy(packet_to_CRC, &total_transmission[ATRCC508A_PROTOCOL_FIELD_LENGTH], transmission_without_crc_length);
+
   //  _debugSerial->println("packet_to_CRC: ");
   //  for (int i = 0; i < sizeof(packet_to_CRC) ; i++)
   //  {
@@ -956,73 +975,20 @@ boolean ATECCX08A::sendCommand(uint8_t command_opcode, uint8_t param1, uint16_t 
   //  _debugSerial->print(",");
   //  }
   //  _debugSerial->println();
-  
-  atca_calculate_crc((total_transmission_length-3), packet_to_CRC); // count includes crc[0] and crc[1], so we must subtract 2 before creating crc
+
+  atca_calculate_crc(transmission_without_crc_length, packet_to_CRC); // count includes crc[0] and crc[1], so we must subtract 2 before creating crc
   //_debugSerial->println(crc[0], HEX);
   //_debugSerial->println(crc[1], HEX);
 
-  memcpy(&total_transmission[total_transmission_length-2], &crc[0], 2);  // append crcs
+  memcpy(&total_transmission[total_transmission_length - ATRCC508A_PROTOCOL_FIELD_SIZE_CRC], &crc[0], ATRCC508A_PROTOCOL_FIELD_SIZE_CRC);  // append crcs
 
   wakeUp();
-  
+
   _i2cPort->beginTransmission(_i2caddr);
-  _i2cPort->write(total_transmission, total_transmission_length); 
+  _i2cPort->write(total_transmission, total_transmission_length);
   _i2cPort->endTransmission();
-  
-  return true;
+
+  err = true;
+error:
+  return err;
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/SparkFun_ATECCX08a_Arduino_Library.h
+++ b/src/SparkFun_ATECCX08a_Arduino_Library.h
@@ -31,13 +31,23 @@
 
 #include "Wire.h"
 
-// Cryptographic defines
-#define PUBLIC_KEY_SIZE    64
-#define SIGNATURE_SIZE     64
-#define CRC_SIZE           2
-#define BUFFER_SIZE        128
-#define CONFIG_ZONE_SIZE   128
-#define SERIAL_NUMBER_SIZE 10
+/* Protocol + Cryptographic defines */
+#define RESPONSE_COUNT_SIZE  1
+#define RESPONSE_SIGNAL_SIZE 1
+#define RESPONSE_INFO_SIZE   4
+#define RESPONSE_RANDOM_SIZE 32
+#define CRC_SIZE             2
+#define CONFIG_ZONE_SIZE     128
+#define SERIAL_NUMBER_SIZE   10
+
+#define PUBLIC_KEY_SIZE      64
+#define SIGNATURE_SIZE       64
+#define BUFFER_SIZE          128
+
+/* Response signals always come after the first count byte */
+#define RESPONSE_COUNT_INDEX 0
+#define RESPONSE_SIGNAL_INDEX RESPONSE_COUNT_SIZE
+#define RESPONSE_GETINFO_SIGNAL_INDEX (RESPONSE_COUNT_SIZE + 2)
 
 /* Protocol Indices */
 #define ATRCC508A_PROTOCOL_FIELD_COMMAND 0
@@ -55,11 +65,31 @@
 #define ATRCC508A_PROTOCOL_FIELD_SIZE_PARAM2  2
 #define ATRCC508A_PROTOCOL_FIELD_SIZE_CRC     CRC_SIZE
 
-// word address val (1) + count (1) + command opcode (1) param1 (1) + param2 (2) data (0-?) + crc (2)
+/* Protocol overhead at sendCommand(): word address val (1) + count (1) + command opcode (1) param1 (1) + param2 (2) data (0-?) + crc (2) */
 #define ATRCC508A_PROTOCOL_OVERHEAD (ATRCC508A_PROTOCOL_FIELD_SIZE_COMMAND + ATRCC508A_PROTOCOL_FIELD_SIZE_LENGTH + ATRCC508A_PROTOCOL_FIELD_SIZE_OPCODE + ATRCC508A_PROTOCOL_FIELD_SIZE_PARAM1 + ATRCC508A_PROTOCOL_FIELD_SIZE_PARAM2 + ATRCC508A_PROTOCOL_FIELD_SIZE_CRC)
 
+/* Protocol codes */
+#define ATRCC508A_SUCCESSFUL_TEMPKEY 0x00
+#define ATRCC508A_SUCCESSFUL_VERIFY  0x00
+#define ATRCC508A_SUCCESSFUL_WRITE   0x00
+#define ATRCC508A_SUCCESSFUL_LOCK    0x00
+#define ATRCC508A_SUCCESSFUL_WAKEUP  0x11
+#define ATRCC508A_SUCCESSFUL_GETINFO 0x50 /* Revision number */
+
+/* Receive constants */
 #define ATRCC508A_MAX_REQUEST_SIZE 32
 #define ATRCC508A_MAX_RETRIES 20
+
+/* configZone EEPROM mapping */
+#define CONFIG_ZONE_READ_SIZE    32
+
+#define CONFIG_ZONE_SERIAL_PART0    0
+#define CONFIG_ZONE_SERIAL_PART1    8
+#define CONFIG_ZONE_REVISION_NUMBER 4
+#define CONFIG_ZONE_OTP_LOCK     86
+#define CONFIG_ZONE_LOCK_STATUS  87
+#define CONFIG_ZONE_SLOTS_LOCK   88
+
 
 #define ATECC508A_ADDRESS_DEFAULT 0x60 //7-bit unshifted default I2C Address
 // 0x60 on a fresh chip. note, this is software definable

--- a/src/SparkFun_ATECCX08a_Arduino_Library.h
+++ b/src/SparkFun_ATECCX08a_Arduino_Library.h
@@ -34,12 +34,14 @@
 /* Protocol + Cryptographic defines */
 #define RESPONSE_COUNT_SIZE  1
 #define RESPONSE_SIGNAL_SIZE 1
+#define RESPONSE_SHA_SIZE    32
 #define RESPONSE_INFO_SIZE   4
 #define RESPONSE_RANDOM_SIZE 32
 #define CRC_SIZE             2
 #define CONFIG_ZONE_SIZE     128
 #define SERIAL_NUMBER_SIZE   10
 
+#define SHA256_SIZE          32
 #define PUBLIC_KEY_SIZE      64
 #define SIGNATURE_SIZE       64
 #define BUFFER_SIZE          128
@@ -47,6 +49,7 @@
 /* Response signals always come after the first count byte */
 #define RESPONSE_COUNT_INDEX 0
 #define RESPONSE_SIGNAL_INDEX RESPONSE_COUNT_SIZE
+#define RESPONSE_SHA_INDEX RESPONSE_COUNT_SIZE
 #define RESPONSE_GETINFO_SIGNAL_INDEX (RESPONSE_COUNT_SIZE + 2)
 
 /* Protocol Indices */
@@ -72,6 +75,7 @@
 #define ATRCC508A_SUCCESSFUL_TEMPKEY 0x00
 #define ATRCC508A_SUCCESSFUL_VERIFY  0x00
 #define ATRCC508A_SUCCESSFUL_WRITE   0x00
+#define ATRCC508A_SUCCESSFUL_SHA     0x00
 #define ATRCC508A_SUCCESSFUL_LOCK    0x00
 #define ATRCC508A_SUCCESSFUL_WAKEUP  0x11
 #define ATRCC508A_SUCCESSFUL_GETINFO 0x50 /* Revision number */
@@ -118,6 +122,12 @@
 // 		_ ? _ _  _ _ _ _ 	Bits 6 Unused, must be zero
 // 		_ _ ? ?  ? ? _ _ 	Bits 5-2 Slot number (in this example, we use slot 0, so "0 0 0 0")
 // 		_ _ _ _  _ _ ? ? 	Bits 1-0 Zone or locktype. 00=Config, 01=Data/OTP, 10=Single Slot in Data, 11=illegal
+
+// SHA Params
+#define SHA_START						0b00000000
+#define SHA_UPDATE						0b00000001
+#define SHA_END							0b00000010
+#define SHA_BLOCK_SIZE					64
 
 #define LOCK_MODE_ZONE_CONFIG 			0b10000000
 #define LOCK_MODE_ZONE_DATA_AND_OTP 	0b10000001
@@ -187,6 +197,9 @@ class ATECCX08A {
 	long getRandomLong(boolean debug = false);
 	long random(long max);
 	long random(long min, long max);
+
+	// SHA256
+	boolean sha256(uint8_t * data, size_t len, uint8_t * hash);
 
 	uint8_t crc[CRC_SIZE] = {0, 0};
 	void atca_calculate_crc(uint8_t length, uint8_t *data);

--- a/src/SparkFun_ATECCX08a_Arduino_Library.h
+++ b/src/SparkFun_ATECCX08a_Arduino_Library.h
@@ -41,6 +41,7 @@
 #define CONFIG_ZONE_SIZE     128
 #define SERIAL_NUMBER_SIZE   10
 
+#define RANDOM_BYTES_BLOCK_SIZE 32
 #define SHA256_SIZE          32
 #define PUBLIC_KEY_SIZE      64
 #define SIGNATURE_SIZE       64


### PR DESCRIPTION
There was a potential integer overflow @ sendCommand() where length could be larger than the protocol overhead, mainly causing erroneous CRC calculation but might cause other types of errors such as a buffer overflow over the packet_to_CRC buffer.
Additionally, refactored the source code to pass variables to the top of functions, correct function exits, self-explanatory protocol while eliminating magic-numbers in the code (mostly around the main protocol).