### PR TITLE
added sleep command

### DIFF
--- a/src/SparkFun_ATECCX08a_Arduino_Library.cpp
+++ b/src/SparkFun_ATECCX08a_Arduino_Library.cpp
@@ -113,6 +113,25 @@ void ATECCX08A::idleMode()
 
 /** \brief
 
+	sleep()
+
+	The ATECCX08A is forcefully put into sleep (LOW POWER) mode and ignores all subsequent I/O transitions
+	until the next wake flag. The contents of TempKey and RNG Seed registers are NOT retained.
+	Idle Power Supply Current: 150nA.
+	This helps avoid waiting for watchdog timer and immidiately puts the device in sleep mode.
+	With this sleep/wakeup cycle, RNG seed registers are updated from internal entropy.
+*/
+
+void ATECCX08A::sleep()
+{
+  idleMode();
+  _i2cPort->beginTransmission(_i2caddr); // set up to write to address
+  _i2cPort->write(WORD_ADDRESS_VALUE_SLEEP); // enter sleep command (aka word address - the first part of every communication to the IC)
+  _i2cPort->endTransmission(); // actually send it
+}
+
+/** \brief
+
 	getInfo()
 
 	This function sends the INFO Command and listens for the correct version (0x50) within the response.

--- a/src/SparkFun_ATECCX08a_Arduino_Library.h
+++ b/src/SparkFun_ATECCX08a_Arduino_Library.h
@@ -121,6 +121,8 @@
 #define WORD_ADDRESS_VALUE_COMMAND 	0x03	// This is the "command" word address,
 //this tells the IC we are going to send a command, and is used for most communications to the IC
 #define WORD_ADDRESS_VALUE_IDLE 0x02 // used to enter idle mode
+//this tells the IC to enter sleep mode
+#define WORD_ADDRESS_VALUE_SLEEP	0x01 // used to enter sleep mode
 
 // COMMANDS (aka "opcodes" in the datasheet)
 #define COMMAND_OPCODE_INFO 	0x30 // Return device state information.
@@ -218,6 +220,7 @@ class ATECCX08A {
 
 	boolean wakeUp();
 	void idleMode();
+	void sleep();
 	boolean getInfo();
 	boolean writeConfigSparkFun();
 	boolean lockConfig(); // note, this PERMINANTLY disables changes to config zone - including changing the I2C address!


### PR DESCRIPTION
  * When requesting huge amount of RNG data, putting device in sleep/wake cycle updates the RNG seed [RNG seed is internally updated at every sleep/wake cycle and power-on event]