### PR TITLE
Increasing delay of the signing operation to work with Arduino WAN 1310

### DIFF
--- a/src/SparkFun_ATECCX08a_Arduino_Library.cpp
+++ b/src/SparkFun_ATECCX08a_Arduino_Library.cpp
@@ -896,7 +896,7 @@ boolean ATECCX08A::signTempKey(uint16_t slot)
   if (!sendCommand(COMMAND_OPCODE_SIGN, SIGN_MODE_TEMPKEY, slot))
     return false;
 
-  delay(60); // time for IC to process command and exectute
+  delay(70); // time for IC to process command and exectute
 
   // Now let's read back from the IC.
   if (!receiveResponseData(RESPONSE_COUNT_SIZE + SIGNATURE_SIZE + CRC_SIZE)) // signature (64), plus crc (2), plus count (1)


### PR DESCRIPTION
The signing operation is taking more than the specified time in the datasheet, consistently. I increased it from 60 and 70 and did some rounds of testing and it is working fine now.

This fixes the issue #13. Note that this can happen to other boards as well.